### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Project purpose
 
-Standalone, third-party-style GitHub Action (Docker-based) that polls the AWS Amplify API for the build status of an app/branch/commit and optionally waits for it to finish before continuing the workflow. Used when a VyOS web property is built remotely on Amplify and downstream CI must gate on the Amplify build outcome.
+Standalone, third-party-style GitHub Action (Docker-based) that polls the AWS Amplify API for the build status of an app/branch and optionally waits for it to finish before continuing the workflow. The `commit-id` input is accepted and validated for presence, but `get_status` retrieves the **most recent** job for the branch via `list-jobs […][0]` — it does not filter by commit SHA. Used when a VyOS web property is built remotely on Amplify and downstream CI must gate on the Amplify build outcome.
 
 ## Tech stack
 
 - Docker-image action (`runs.using: docker`, `image: Dockerfile`).
 - `alpine:3.19` base + `aws-cli` + `jq`.
-- Shell `entrypoint.sh`.
+- Shell `entrypoint.sh` (uses bash-specific `[[ ]]` syntax despite `#!/bin/sh -l` shebang — see Notes).
 
 ## Build / test / run
 
@@ -43,8 +43,7 @@ Generic GHA action — not part of the VyOS image build pipeline. Likely consume
 ## Conventions
 
 - Commit / PR title format: `component: T12345: description` (Phorge task ID mandatory). Enforced by `vyos/.github` reusable workflows where consumed.
-- Branch model: `current` (rolling), `circinus` (1.5 LTS), `sagitta` (1.4 LTS), `equuleus` (1.3 LTS).
-- Released by tag (`v1`, `v1.1`, `v2.0`, `v2.1`, `v2.2`); consumers pin `@vX.Y` rather than `@current`.
+- Released by tag (`v1`, `v1.1`, `v2.0`, `v2.1`, `v2.2`); consumers pin `@vX.Y`.
 
 ## Mirror relationship
 
@@ -55,3 +54,6 @@ No mirror twin.
 - Likely a fork or rewrite of `duckbytes/amplify-build-status` (README example references that source).
 - License: MIT.
 - AWS credentials are passed via env from the calling workflow — never bake them into the image.
+- **Shebang vs syntax**: `entrypoint.sh` declares `#!/bin/sh -l` but uses bash-specific `[[ ]]` throughout. Works on Alpine because busybox ash supports `[[ ]]`, but it is not strictly POSIX sh.
+- **Known issue – output name mismatch**: `entrypoint.sh` writes `environment_name=…` to `$GITHUB_OUTPUT`, but `action.yml` declares the output key as `backend_environment`. Consumers referencing `steps.<id>.outputs.backend_environment` will get an empty value.
+- **Known issue – hardcoded project name**: `get_backend_graphql_endpoint` contains a hardcoded `platelet` API name (`jq -r ".api.platelet.output.GraphQLAPIEndpointOutput"`). This function is only useful for the original consumer project; other consumers will get a null endpoint.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,3 @@ No mirror twin.
 - Likely a fork or rewrite of `duckbytes/amplify-build-status` (README example references that source).
 - License: MIT.
 - AWS credentials are passed via env from the calling workflow — never bake them into the image.
-
----
-
-This file is mirrored on Confluence: [`vyos/amplify-build-status`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818282850). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+## Project purpose
+
+Standalone, third-party-style GitHub Action (Docker-based) that polls the AWS Amplify API for the build status of an app/branch/commit and optionally waits for it to finish before continuing the workflow. Used when a VyOS web property is built remotely on Amplify and downstream CI must gate on the Amplify build outcome.
+
+## Tech stack
+
+- Docker-image action (`runs.using: docker`, `image: Dockerfile`).
+- `alpine:3.19` base + `aws-cli` + `jq`.
+- Shell `entrypoint.sh`.
+
+## Build / test / run
+
+Used as a step inside a consumer workflow:
+
+```yaml
+- uses: vyos/amplify-build-status@v2.2
+  with:
+    app-id:      ${{ secrets.AMPLIFY_APP_ID }}
+    branch-name: ${{ github.ref_name }}
+    commit-id:   ${{ github.sha }}
+    wait:        true
+  env:
+    AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    AWS_REGION:            ${{ secrets.AWS_REGION }}
+```
+
+To test locally: `docker build -t amplify-status .` then run `docker run amplify-status <app-id> <branch> <commit> <wait> <timeout> <no-fail>` with AWS env vars set.
+
+## Repository layout
+
+- `action.yml` — action metadata (inputs/outputs/runs).
+- `Dockerfile` — alpine + aws-cli + jq.
+- `entrypoint.sh` — shell logic that calls `aws amplify` and parses with `jq`.
+- `LICENSE` (MIT), `README.md`.
+
+## Cross-repo context
+
+Generic GHA action — not part of the VyOS image build pipeline. Likely consumed by `sentrium/*` Next.js sites or similar Amplify-hosted properties. No mirror twin; not referenced by `vyos-build-packages/repos.toml`.
+
+## Conventions
+
+- Commit / PR title format: `component: T12345: description` (Phorge task ID mandatory). Enforced by `vyos/.github` reusable workflows where consumed.
+- Branch model: `current` (rolling), `circinus` (1.5 LTS), `sagitta` (1.4 LTS), `equuleus` (1.3 LTS).
+- Released by tag (`v1`, `v1.1`, `v2.0`, `v2.1`, `v2.2`); consumers pin `@vX.Y` rather than `@current`.
+
+## Mirror relationship
+
+No mirror twin.
+
+## Notes for future contributors
+
+- Likely a fork or rewrite of `duckbytes/amplify-build-status` (README example references that source).
+- License: MIT.
+- AWS credentials are passed via env from the calling workflow — never bake them into the image.
+
+---
+
+This file is mirrored on Confluence: [`vyos/amplify-build-status`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818282850). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
