### PR TITLE
general: T8765: CodeRabbit central-baseline verification probe (smoke test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ Amplify will successfully complete the new build, but it is necessary click `(Ed
 
 If you are connecting a branch to Amplify for the first time, the commit-id may be `HEAD` instead of the commit sha.
 Any subsequent builds triggered by commits will use the actual commit sha.
+
+<!-- T8765/T8766 CodeRabbit central-baseline verification probe — 2026-05-09 -->


### PR DESCRIPTION
**CodeRabbit central-baseline verification probe** — T8765 / T8766 acceptance test.

Trivial whitespace addition to README to trigger a CodeRabbit walkthrough. Pass criteria (per spec):
- walkthrough cites `coderabbit/.coderabbit.yaml`
- tools list reflects baseline (gitleaks, semgrep, markdownlint, yamllint, actionlint)
- `drafts: false` honored — re-marking draft skips review

This PR will be **closed-not-merged** once verified.

🤖 Generated by [robots](https://vyos.io)